### PR TITLE
Add xAI image provider

### DIFF
--- a/inc/providers/class-image-provider-xai.php
+++ b/inc/providers/class-image-provider-xai.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * xAI API provider implementation for KaiGen.
+ *
+ * @package KaiGen
+ */
+
+namespace KaiGen\Providers;
+
+use KaiGen\Image_Provider;
+use WP_Error;
+
+/**
+ * xAI API provider implementation for KaiGen.
+ *
+ * Handles image generation and editing using xAI's image API.
+ */
+class Image_Provider_XAI extends Image_Provider {
+	/**
+	 * The base URL for the xAI image generation API.
+	 */
+	private const API_BASE_URL = 'https://api.x.ai/v1/images/generations';
+
+	/**
+	 * The base URL for the xAI image edit API.
+	 */
+	private const IMAGE_EDIT_API_BASE_URL = 'https://api.x.ai/v1/images/edits';
+
+	/**
+	 * Default xAI image model.
+	 */
+	private const DEFAULT_MODEL = 'grok-imagine-image';
+
+	/**
+	 * Gets the unique identifier for this provider.
+	 *
+	 * @return string The unique identifier for this provider.
+	 */
+	public function get_id() {
+		return 'xai';
+	}
+
+	/**
+	 * Gets the display name for this provider.
+	 *
+	 * @return string The display name for this provider.
+	 */
+	public function get_name() {
+		return 'xAI';
+	}
+
+	/**
+	 * Gets the current model being used by the provider.
+	 *
+	 * @return string The current model identifier.
+	 */
+	public function get_current_model() {
+		return $this->model ? $this->model : self::DEFAULT_MODEL;
+	}
+
+	/**
+	 * Makes the API request to generate an image.
+	 *
+	 * @param string $prompt The text prompt for image generation.
+	 * @param array  $additional_params Additional parameters for image generation.
+	 * @return array|WP_Error The API response or error.
+	 */
+	public function make_api_request( $prompt, $additional_params = [] ) {
+		if ( ! $this->validate_api_key() ) {
+			return new WP_Error( 'invalid_api_key_format', 'API key format is invalid.' );
+		}
+
+		$source_image_urls = $additional_params['source_image_urls'] ?? [];
+		$source_image_url  = $additional_params['source_image_url'] ?? null;
+		if ( $source_image_url ) {
+			array_unshift( $source_image_urls, $source_image_url );
+		}
+
+		$source_image_urls = array_values( array_unique( array_filter( $source_image_urls ) ) );
+		$has_source_image  = ! empty( $source_image_urls );
+
+		$endpoint = $has_source_image ? self::IMAGE_EDIT_API_BASE_URL : self::API_BASE_URL;
+
+		$body = [
+			'model'  => $this->get_model_for_request( $additional_params['quality'] ?? '', $additional_params ),
+			'prompt' => $prompt,
+		];
+
+		if ( $has_source_image ) {
+			$body['image'] = $source_image_urls[0];
+		}
+
+		if ( ! empty( $additional_params['aspect_ratio'] ) ) {
+			$body['aspect_ratio'] = $additional_params['aspect_ratio'];
+		}
+
+		if ( ! empty( $additional_params['num_outputs'] ) ) {
+			$body['n'] = max( 1, min( 10, (int) $additional_params['num_outputs'] ) );
+		}
+
+		$headers = $this->get_request_headers();
+		$body    = wp_json_encode( $body );
+
+		$response = wp_remote_post(
+			$endpoint,
+			[
+				'headers' => $headers,
+				'body'    => $body,
+				'timeout' => 180,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'xai_error', 'xAI API request failed: ' . $response->get_error_message() );
+		}
+
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			$error_data = json_decode( $response_body, true );
+			if ( isset( $error_data['error']['message'] ) ) {
+				return new WP_Error( 'xai_error', $error_data['error']['message'] );
+			}
+
+			return new WP_Error( 'api_error', "API Error (HTTP $response_code): $response_body" );
+		}
+
+		return json_decode( $response_body, true );
+	}
+
+	/**
+	 * Processes the API response to extract the image URL or data.
+	 *
+	 * @param mixed $response The API response to process.
+	 * @return string|WP_Error The image URL/data or error.
+	 */
+	public function process_api_response( $response ) {
+		if ( ! empty( $response['error'] ) ) {
+			return new WP_Error( 'xai_error', $response['error']['message'] ?? 'Unknown error occurred' );
+		}
+
+		if ( empty( $response['data'] ) || ! is_array( $response['data'] ) ) {
+			return new WP_Error( 'xai_error', 'Invalid response format from xAI' );
+		}
+
+		if ( empty( $response['data'][0]['url'] ) && empty( $response['data'][0]['b64_json'] ) ) {
+			return new WP_Error( 'xai_error', 'Missing image data in xAI response' );
+		}
+
+		if ( ! empty( $response['data'][0]['url'] ) ) {
+			$image_url = $response['data'][0]['url'];
+
+			if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+				return new WP_Error( 'xai_error', 'Invalid image URL in response' );
+			}
+
+			return $image_url;
+		}
+
+		$b64_json = $response['data'][0]['b64_json'];
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding API response, not obfuscation.
+		$image_data = base64_decode( $b64_json );
+
+		if ( ! $image_data ) {
+			return new WP_Error( 'xai_error', 'Invalid base64 image data in response' );
+		}
+
+		return $image_data;
+	}
+
+	/**
+	 * Validates the API key format according to xAI requirements.
+	 *
+	 * @return bool True if the API key is valid, false otherwise.
+	 */
+	public function validate_api_key() {
+		return ! empty( $this->api_key );
+	}
+
+	/**
+	 * Gets the available models for xAI.
+	 *
+	 * @return array List of available models.
+	 */
+	public function get_available_models() {
+		return [
+			self::DEFAULT_MODEL => 'Grok Imagine Image (xAI)',
+		];
+	}
+
+	/**
+	 * Resolves the model to use for a request.
+	 *
+	 * @param string $quality_setting Optional quality setting.
+	 * @param array  $additional_params Optional additional parameters for the request.
+	 * @return string The resolved model identifier.
+	 */
+	public function get_model_for_request( $quality_setting = '', $additional_params = [] ) {
+		return $this->model ? $this->model : self::DEFAULT_MODEL;
+	}
+
+	/**
+	 * Gets the estimated image generation time in seconds.
+	 *
+	 * @param string $quality_setting Optional quality setting.
+	 * @param array  $additional_params Optional additional parameters for estimation.
+	 * @return int Estimated time in seconds.
+	 */
+	public function get_estimated_generation_time( $quality_setting = '', $additional_params = [] ) {
+		return 30;
+	}
+
+	/**
+	 * Gets the maximum number of reference images supported for a request.
+	 *
+	 * @param string $quality_setting Optional quality setting.
+	 * @param array  $additional_params Optional additional parameters for the request.
+	 * @return int The maximum number of reference images.
+	 */
+	public function get_max_reference_images( $quality_setting = '', $additional_params = [] ) {
+		return 1;
+	}
+}
+
+/**
+ * Registers the filter to format the xAI provider name.
+ *
+ * This filter is registered at module load time so it's available when
+ * the provider manager formats provider names during class loading.
+ */
+add_filter(
+	'kaigen_format_provider_name',
+	function ( $formatted_name, $name, $name_lower ) {
+		if ( 'xai' === $name_lower ) {
+			return 'xAI';
+		}
+		return $formatted_name;
+	},
+	10,
+	3
+);

--- a/tests/http-mock.php
+++ b/tests/http-mock.php
@@ -87,6 +87,25 @@ add_filter(
 					'cookies'  => [],
 					'filename' => '',
 				];
+			} elseif ( str_contains( $url, 'api.x.ai' ) ) {
+				return [
+					'headers'  => [ 'content-type' => 'application/json' ],
+					'body'     => wp_json_encode(
+						[
+							'error' => [
+								'message' => 'Your request was rejected as a result of our safety system.',
+								'type'    => 'invalid_request_error',
+								'code'    => 'content_policy_violation',
+							],
+						]
+					),
+					'response' => [
+						'code'    => 400,
+						'message' => 'Bad Request',
+					],
+					'cookies'  => [],
+					'filename' => '',
+				];
 			}
 		}
 
@@ -156,6 +175,64 @@ add_filter(
 		if ( str_contains( $url, 'api.openai.com/v1/images/edits' ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'KaiGen E2E Mock: Returning mocked OpenAI edit response' );
+
+			$placeholder_base64 = 'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAfUlEQVR42u3RAQ0AAAjDMO5fNCxICg0B0FEBGUgDJSMpIyljKSMrYykhKSMpYyklKWOpIyllKSMpYykhKSMpYyklKSMpYyklKWOpIyllKSMpYykhKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKWOpIyllKWw/4Ab2agQMAAAAAElFTkSuQmCC';
+
+			return [
+				'headers'  => [ 'content-type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'created' => time(),
+						'data'    => [
+							[
+								'b64_json'       => $placeholder_base64,
+								'revised_prompt' => 'An edited version of the original image',
+							],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => '',
+			];
+		}
+
+		// Mock xAI image generation endpoint.
+		if ( str_contains( $url, 'api.x.ai/v1/images/generations' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'KaiGen E2E Mock: Returning mocked xAI generation response' );
+
+			$png_base64   = 'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAPJJREFUSEvt1M0RgjAQBOCWq3QD3SA36QbphGyQbpBuoG4g3SAdwAbtJg7sCg7QhZAEb3L5l5CQUlq4W3h5IcwQ2gU3nd23sQggoZoJAxzEa243u0G2QAvzKLRNC9gQwpIBbeoV0A+w/wN8AcflGqY7QPl4gA3kNaYg9k/wbQCNY3E0sA0LDUQx3wFj2Gr+C8wd4AxbMMSx3wBs5piO2b4C3MwzzHds3gFv5hjO274CPs0xzHcv3gFv5hrW2z4C3s0wrLf8BrOYZ1lv+wns5plWW/4DOs9zLP8B7OYZ1mGfAQTwC3b3/wFSGddpE8wD/gAAAABJRU5ErkJggg==';
+
+			return [
+				'headers'  => [ 'content-type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'created' => time(),
+						'data'    => [
+							[
+								'b64_json'       => $png_base64,
+								'revised_prompt' => 'A bright test pattern with a green checkmark.',
+							],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => '',
+			];
+		}
+
+		// Mock xAI image edit endpoint.
+		if ( str_contains( $url, 'api.x.ai/v1/images/edits' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'KaiGen E2E Mock: Returning mocked xAI edit response' );
 
 			$placeholder_base64 = 'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAfUlEQVR42u3RAQ0AAAjDMO5fNCxICg0B0FEBGUgDJSMpIyljKSMrYykhKSMpYyklKWOpIyllKSMpYykhKSMpYyklKSMpYyklKWOpIyllKSMpYykhKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKSMpYyklKWOpIyllKWw/4Ab2agQMAAAAAElFTkSuQmCC';
 


### PR DESCRIPTION
### Motivation
- Add support for xAI (Grok Imagine Image) as an image generation and edit provider so KaiGen can call xAI's image endpoints and be selectable in the plugin provider list.
- Include mocked xAI responses in the E2E HTTP mock so tests and local development can exercise xAI flows without network calls.

### Description
- Added a new provider implementation at `inc/providers/class-image-provider-xai.php` that implements request building (`make_api_request`), response parsing (`process_api_response`), model selection, API key validation, estimated timings, and provider name formatting.
- The provider sends JSON requests to `https://api.x.ai/v1/images/generations` and `https://api.x.ai/v1/images/edits`, supports `prompt`, `model`, `aspect_ratio`, and multiple-output (`n`) parameters, and returns either a URL or base64 image data for upload.
- Updated `tests/http-mock.php` to mock xAI error, generation, and edit endpoints so E2E runs can simulate xAI responses consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e9344aa40832e999d864814cd302b)