### PR TITLE
Configure Playground workers for E2E

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 const playgroundPort = process.env.PLAYGROUND_PORT || '9400';
+const playgroundWorkers = process.env.PLAYGROUND_WORKERS || '6';
 const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEBSERVER === '1';
 
 export default defineConfig( {
@@ -76,7 +77,7 @@ export default defineConfig( {
 	webServer: skipWebServer
 		? undefined
 		: {
-				command: `npx @wp-playground/cli server --mount=.:/wordpress/wp-content/plugins/kaigen --blueprint=.github/blueprints/e2e-test.json --port=${ playgroundPort }`,
+				command: `npx @wp-playground/cli server --mount=.:/wordpress/wp-content/plugins/kaigen --blueprint=.github/blueprints/e2e-test.json --port=${ playgroundPort } --workers=${ playgroundWorkers }`,
 				url: `http://127.0.0.1:${ playgroundPort }`,
 				reuseExistingServer: ! process.env.CI,
 				timeout: 120_000,


### PR DESCRIPTION
What changed

The Playwright web server now starts WordPress Playground with six workers by default. PLAYGROUND_WORKERS can override the count for local debugging.

Why

GitHub hosted runners expose four CPUs, so Playground previously selected three workers and warned that fewer than six workers can increase the likelihood of deadlocks while requests wait on file locks.

Impact

E2E tests retain one Playwright worker and one shared Playground instance, while the Playground server has enough request workers to avoid the warning and reduce file lock deadlock risk.

Validation

npm run test:e2e:launcher
npm run lint:js
npm run test:e2e