### PR TITLE
Skip redundant Playwright system dependency setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Install only Chromium browser for speed
       - name: Install Chromium only
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       # Run E2E tests (Playwright starts WordPress Playground automatically via webServer config)
       - name: Run E2E tests


### PR DESCRIPTION
The E2E workflow now skips Playwright's redundant Linux system dependency setup while continuing to install the Chromium browser itself.

The linked successful Actions job showed that the browser cache hit and the GitHub hosted runner already had most required system libraries. The --with-deps step still spent roughly 12 seconds running apt and font setup: https://github.com/jacobschweitzer/KaiGen/actions/runs/29606771625/job/87971790544?pr=55

Validation was limited to parsing the workflow as YAML and checking the diff for whitespace errors. The full E2E suite was intentionally not run locally because it cannot validate the system libraries available on GitHub's hosted runner. The PR workflow run is the meaningful validation for that assumption.
